### PR TITLE
Remove references to debug mode

### DIFF
--- a/docs/editors/intellij.md
+++ b/docs/editors/intellij.md
@@ -22,7 +22,7 @@ There you can instruct IntelliJ on how to start the server. Select
 `Raw Command`, set `erl;hrl` as the extension, then add as the
 command:
 
-    /ABSOLUTE/PATH/TO/erlang_ls/_build/debug/bin/erlang_ls --transport stdio
+    /ABSOLUTE/PATH/TO/erlang_ls/_build/default/bin/erlang_ls --transport stdio
 
 Ensure you use an absolute path. The plugin does not seem to
 understand the `~` symbol. For the above command to work, IntelliJ

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,15 +1,6 @@
 # Troubleshooting
 
-## Debug Mode
-
-It is possible to compile and start the language server in _debug mode_:
-
-    rebar3 as debug escriptize
-
-Ensure you update your `PATH` to include the new executable which now
-resides in:
-
-    /path/to/erlang_ls/_build/debug/bin/erlang_ls
+## Attaching to the Language Server via a Remote Shell
 
 Once an instance of the server is running, find the name of the node in
 the [logs](#logs) or by running `epmd -names`. It will look something like:
@@ -23,14 +14,13 @@ And you can connect to it via:
     erl -sname debug -remsh erlang_ls_62880311918@`HOSTNAME`
 
 The [redbug](https://github.com/massemanet/redbug) application is
-included in _debug mode_, so feel free to use it.
+included in the escript, so feel free to use it.
 
 ## Logging
 
-When the escript is built using the `debug` profile as above, logging
-will be enabled and the logs will be written to your platform's log
-directory (i.e. the return value from `filename:basedir(user_log,
-"erlang_ls")`), in a file named `server.log`.
+Logs are written to your platform's log directory (i.e. the return
+value from `filename:basedir(user_log, "erlang_ls")`), in a file named
+`server.log`.
 
 It's possible to customize the logging directory by using the
 `--log-dir` option when starting the server.
@@ -40,6 +30,3 @@ It's also possible to specify the verbosity of the logs by using the
 `warning` and `error` levels, [syslog style loglevel comparison
 flags](https://github.com/erlang-lager/lager#syslog-style-loglevel-comparison-flags)
 can also be used.
-
-When the `escript` is built in the `default` mode (i.e. `rebar3 escript`),
-no log files are generated, unless the `--log-dir` option is provided.


### PR DESCRIPTION
As part of erlang_ls#560 we are removing the separation between `debug` and `default` mode. Logging is now enabled by default and `debug` is just an alias to the `default` mode which we will eventually remove.