### PR TITLE
docs: Troubleshooting updates

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,21 @@ the [logs](#logs) or by running `epmd -names`. It will look something like:
 
 And you can connect to it via:
 
-    erl -sname debug -remsh erlang_ls_62880311918@`HOSTNAME`
+    $ erl -sname debug -remsh erlang_ls_62880311918@`HOSTNAME`
+
+If you see this error like this:
+
+```*** ERROR: Shell process terminated! (^G to start new job) ***
+=ERROR REPORT==== 5-Jun-2020::15:53:07.270087 ===
+** System NOT running to use fully qualified hostnames **
+** Hostname Host-Name-Here.local is illegal **
+```
+
+Then try running the command without the `@HOSTNAME` at the end,
+like so:
+
+
+    $ erl -sname debug -remsh erlang_ls_62880311918
 
 The [redbug](https://github.com/massemanet/redbug) application is
 included in the escript, so feel free to use it.
@@ -19,8 +33,11 @@ included in the escript, so feel free to use it.
 ## Logging
 
 Logs are written to your platform's log directory (i.e. the return
-value from `filename:basedir(user_log, "erlang_ls")`), in a file named
-`server.log`.
+value from `filename:basedir(user_log, "erlang_ls").`), in a file named
+`server.log`. For example on a Mac, the default location is
+`/Users/USERNAME/Library/Logs/PROJECTDIR/server.log`, where USERNAME and
+PROJECTDIR are your operating system's user account name and the project
+folder that logs were generated for, respectively.
 
 It's possible to customize the logging directory by using the
 `--log-dir` option when starting the server.


### PR DESCRIPTION
* Added directions if you get an error about fully qualified hostnames while running `erl -sname debug -remsh erlang_ls_62880311918@`HOSTNAME`
* Added a `.` to the end of the `filename:basedir(user_log, "erlang_ls")` Erlang command to reduce confusion for beginners.
* Added example of where the server logs will be for a Mac user.