### PR TITLE
Add note: to run a local mkdocs server you may also require Material for mkdocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ static website which gets automatically deployed to _GitHub pages_
 whenever a Pull Request is merged to the `mkdocs` branch.
 
 To try the changes locally, simply: `mkdocs serve`
+
+- Note: you might have to [install Material for MkDocs](https://squidfunk.github.io/mkdocs-material/getting-started/)

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -20,7 +20,7 @@ may need to prune or amend this file if you change your mind about
 blacklisting a project or if you erroneously select a project
 root. For more information about the `lsp-session-file` and
 `emacs-lsp` in general, please refer to the [official
-documentation](https://github.com/emacs-lsp/lsp-mode/blob/master/README.org).
+documentation](https://emacs-lsp.github.io/lsp-mode/).
 
 Remember that the Erlang Language Server requires Erlang/OTP 21 or
 higher to run, so ensure that OTP 21+ is available in your `PATH`.


### PR DESCRIPTION
And add a link to the instructions to install Material for MkDocs.